### PR TITLE
[Add] handle gpio_base for pin > 31 on rp2350

### DIFF
--- a/src/pio_encoder.cpp
+++ b/src/pio_encoder.cpp
@@ -34,15 +34,35 @@ PioEncoder::PioEncoder(const uint8_t pin, const bool flip, const int zero_offset
 void PioEncoder::begin(){
     pinMode(pin, INPUT);
     pinMode(pin+1, INPUT);
+    int base = 0;
 
+    /* checks which pin range and set upper rp2350
+     * 0-31 or > 32
+     * and assigns the base. 
+     * */
+    
+    if(pin > 31 && pio_get_gpio_base(pio) == 0) {
+        this->pio = PIO pio1;
+        pio_set_gpio_base(pio, 0x10);
+        //base = 16;
+    } else if (pin < 31) {
+        this->pio = PIO pio0;
+        pio_set_gpio_base(pio, 0);
+        base = 0;
+    }
+    
     if (!not_first_instance){
         offset = pio_add_program(pio, &quadrature_encoder_program);
     }
+
     not_first_instance=true;
+
     if (sm==-1){
         sm = pio_claim_unused_sm(pio, true);
     }
+
     sm=sm;
+
     quadrature_encoder_program_init(pio,sm,offset,pin,max_step_rate);
 }
 

--- a/src/pio_encoder.cpp
+++ b/src/pio_encoder.cpp
@@ -20,7 +20,8 @@
 uint PioEncoder::offset;
 bool PioEncoder::not_first_instance;
 
-PioEncoder::PioEncoder(const uint8_t pin, const bool flip, const int zero_offset, const uint8_t count_mode, PIO pio, const uint sm, const int max_step_rate){
+
+PioEncoder::PioEncoder(const uint pin, PIO pio, const uint sm, const bool flip, const int zero_offset, const uint8_t count_mode, const int max_step_rate){
     static uint offset;
     this->pin = pin;
     this->pio = pio;
@@ -34,23 +35,12 @@ PioEncoder::PioEncoder(const uint8_t pin, const bool flip, const int zero_offset
 void PioEncoder::begin(){
     pinMode(pin, INPUT);
     pinMode(pin+1, INPUT);
-    int base = 0;
 
-    /* checks which pin range and set upper rp2350
-     * 0-31 or > 32
-     * and assigns the base. 
-     * */
-    
-    if(pin > 31 && pio_get_gpio_base(pio) == 0) {
+    if(pin > 31 && pio_get_gpio_base(pio) != 16) {
         this->pio = PIO pio1;
-        pio_set_gpio_base(pio, 0x10);
-        //base = 16;
-    } else if (pin < 31) {
-        this->pio = PIO pio0;
-        pio_set_gpio_base(pio, 0);
-        base = 0;
+        pio_set_gpio_base(pio, 16);
     }
-    
+     
     if (!not_first_instance){
         offset = pio_add_program(pio, &quadrature_encoder_program);
     }
@@ -62,9 +52,12 @@ void PioEncoder::begin(){
     }
 
     sm=sm;
-
+    // this does NOT work with both ranges.
+    //bool success = pio_claim_free_sm_and_add_program_for_gpio_range(&quadrature_encoder_program, &pio, &sm, &offset, pin, 1, true);
+    //
     quadrature_encoder_program_init(pio,sm,offset,pin,max_step_rate);
 }
+
 
 void PioEncoder::reset(const int reset_value){
     quadrature_encoder_reset(pio, sm);
@@ -83,6 +76,7 @@ void PioEncoder::flip(const bool x){
 void PioEncoder::setMode(const uint8_t mode){
     count_mode = mode;
 }
+
 
 int PioEncoder::getCount(){
     return flip_it*(quadrature_encoder_get_count(pio, sm)>>count_mode)+zero_offset;

--- a/src/pio_encoder.h
+++ b/src/pio_encoder.h
@@ -28,7 +28,7 @@
 
 class PioEncoder{
     private:
-        uint8_t pin;
+        uint pin;
         uint sm;
         PIO pio;
         int max_step_rate;
@@ -39,8 +39,8 @@ class PioEncoder{
         static uint offset;
         static bool not_first_instance;
         
-        PioEncoder(const uint8_t pin, const bool flip = false, const int zero_offset = 0, const uint8_t count_mode = COUNT_4X,
-                   PIO pio = pio0, const uint sm = -1, const int max_step_rate = 0);
+        PioEncoder(const uint pin, PIO pio = pio0, const uint sm = -1, const bool flip = false, 
+                   const int zero_offset = 0, const uint8_t count_mode = COUNT_4X, const int max_step_rate = 0);
         void begin();
         void reset(const int reset_value = 0);
         void flip(const bool x=true);
@@ -49,4 +49,6 @@ class PioEncoder{
 };
 
 
+
 #endif
+


### PR DESCRIPTION
This is a fairly dangerous thing to do :) The way I'm assigning PIO pio0 or pio1 could cause issues. I'm using it fine with a number of other libraries BUT, if you mix (as I do) a lower range (pin 2, say) with higher (pin 32, say) you need to make sure you begin() the lower range first. I'm also initializing the encoders before other things in sketches (I have I2S dac, a display and 4 buttons in the demo).

This is a fairly tricky change so I can imagine you would reject. But it's small :)

I better solution would probably, as here from the pico-sdk examples,  be:
```
 pio_claim_free_sm_and_add_program_for_gpio_range(&ws2812_parallel_program, &pio, &sm, &offset, WS2812_PIN_BASE, count_of(strips), true);
```